### PR TITLE
fix: Add missing row to table display by adding extra index

### DIFF
--- a/front-end/src/components/CustomNode/GraphView.js
+++ b/front-end/src/components/CustomNode/GraphView.js
@@ -111,7 +111,7 @@ export default class GraphView extends React.Component {
 
       return (
         <div className={className} style={style}>
-          {(rowIndex === 0) ? column : this.state.data[column][rowIndex.toString()]}
+          {(rowIndex === 0) ? column : this.state.data[column][(rowIndex - 1).toString()]}
         </div>
       );
     };
@@ -168,7 +168,7 @@ export default class GraphView extends React.Component {
                       columnCount={this.state.columns.length}
                       columnWidth={index => this.columnWidths(index)}
                       height={displayHeight < 600 ? displayHeight + 5 : 600}
-                      rowCount={this.state.rows.length}
+                      rowCount={this.state.rows.length + 1}
                       rowHeight={index => 20}
                       width={displayWidth < 900 ? displayWidth : 900}
                   >


### PR DESCRIPTION
The fix is easier than I thought. To account for the grid's index 0 being the column data, add 1 to `rowCount` and subtract 1 from `rowIndex` when creating the cell. So data is displayed like:

```
Row 0 == column
Row 1 == row 1-1 == row 0
...
```
This shouldn't cause any off-by-1 errors, since the difference is accounted for by the column data.