### PR TITLE
Fix: Update front-end Dockerfile to pull in package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,12 @@ Note: there [is a known issue with `react-scripts` v3.4.1](https://github.com/fa
 that may cause the front-end container to exit with code 0. If this happens,
 you can add `-e CI=true` to the `docker-run` command above for the front-end.
 
-NOTE: For development outside of Docker, change ./front-end/package.json from "proxy": "http://back-end:8000" to "http://localhost:8000" to work.
+NOTE: For development outside of Docker, change `./front-end/package.json`
+from `"proxy": "http://back-end:8000"` to `"proxy": http://localhost:8000"` to work.
 
+After the Docker containers are started, and both front- and back-ends are running,
+you can access the application by loading [http://localhost:3000/](http://localhost:3000/)
+in your browser.
 
 ## Serve locally
 
@@ -139,6 +143,10 @@ npm install
 ```
 npm start
 ```
+
+By default, the `react-scripts` should open your default browser to the main
+application page. If not, you can go to [http://localhost:3000/](http://localhost:3000/)
+in your browser.
 
 # CLI
 PyWorkflow also provides a command-line interface to execute pre-built workflows

--- a/front-end/Dockerfile
+++ b/front-end/Dockerfile
@@ -3,6 +3,7 @@ FROM node:14-alpine
 WORKDIR /visual-programming/front-end
 
 COPY package.json .
+COPY package-lock.json .
 
 RUN npm install
 


### PR DESCRIPTION
Before, the Dockerfile for the front-end container would use `package.json` to rebuild the dependency list. This includes some package changes since the last-tested commit/versions back in May. By adding the `package-lock.json` file we can ensure the package versions match what we last tested/built on. This seems to solve the issues when running `docker-compose up --build` to get the project up-and-running.